### PR TITLE
fix: updated steam client lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.27.1
-steam[client]==1.2.0
+steam[client]==1.3.0


### PR DESCRIPTION
Updated steam client lib due to a [\[BUG\] SteamClient fails with an AttributeError when importing Protobuf\[4.21.0\]](https://github.com/ValvePython/steam/issues/385) fixed in commit [5d35642](https://github.com/ValvePython/steam/commit/5d356425198a7a3b2bfbcc7d930ae35d618e250c)